### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server implementation that provides access to JIRA data with relationship tracking, optimized data payloads, and data cleaning for AI context windows.
 
+<a href="https://glama.ai/mcp/servers/@cosmix/jira-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cosmix/jira-mcp/badge" alt="JIRA Server MCP server" />
+</a>
+
 ℹ️ There is a separate MCP server [for Confluence](https://github.com/cosmix/confluence-mcp)
 
 ## Features


### PR DESCRIPTION
This PR adds a badge for the [JIRA MCP Server](https://glama.ai/mcp/servers/@cosmix/jira-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@cosmix/jira-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@cosmix/jira-mcp/badge" alt="JIRA Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.